### PR TITLE
Eliminated problematic show() in FITS_Reader.java.

### DIFF
--- a/src/main/java/ij/plugin/FITS_Reader.java
+++ b/src/main/java/ij/plugin/FITS_Reader.java
@@ -117,8 +117,6 @@ public class FITS_Reader extends ImagePlus implements PlugIn {
             displayStackedImage();
         }
 
-        show();
-
         IJ.showStatus("");
     }
 


### PR DESCRIPTION
Normally show() is idempotent and innocuous, at worst causing a performance hit. However, because ImagePlus.show() finishes by notifying listeners that an image has been opened, and because the Astronomy plugin has hooked that notification to instantiate an AstroStackWindow, the call to show() in FITS_Reader is actually a pretty big problem, causing multiple AstroStackWindows to be instantiated, (because each AstroStackWindow then instantiates another FITS_Reader). I'm not even sure what was arresting the recursion.